### PR TITLE
[config] sources 添加“延河”

### DIFF
--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -58,6 +58,9 @@ export interface NoticeInterface {
     title: string
     date: Date | null
 
+    /** 标识符，在（所有来源的）所有通知中唯一，一般无需指定，直接采用`link` */
+    id?: string
+
     /** 通知来源或 id */
     source: Source | string
 }
@@ -75,13 +78,13 @@ export class Notice {
     source?: Source
     #source_ref: Source | string
 
-    constructor ({ link, title, date, source }: NoticeInterface) {
+    constructor ({ link, title, date, source, id }: NoticeInterface) {
         this.link = link
         this.title = title
         this.date = date
         this.#source_ref = source
 
-        this.id = this.link
+        this.id = id ?? this.link
     }
 
     populate ({ sources }: { sources?: Source[] }) {
@@ -140,6 +143,7 @@ export class Notice {
             title: this.title,
             date: this.date,
             source: this.source_id,
+            ...(this.id === this.link ? {} : { id: this.id }),
         } as NoticeInterface
     }
 

--- a/src/core/sources/special.ts
+++ b/src/core/sources/special.ts
@@ -12,6 +12,7 @@ interface NoticeWithoutSource {
     link: string
     title: string
     date: Date | null
+    id?: string
 }
 
 interface SourceSpecialInterface extends SourceInterface {
@@ -153,8 +154,8 @@ const sources = raw_sources.map(raw => {
     const source = new Source(raw)
     source.fetch_notice = async ({ _hook }) => {
         const notices = await raw.fetch_notice({ _hook })
-        return notices.map(({ link, title, date }) =>
-            new Notice({ link, title, date, source }),
+        return notices.map(({ link, title, date, id }) =>
+            new Notice({ link, title, date, source, id }),
         )
     }
     return source

--- a/src/core/sources/special.ts
+++ b/src/core/sources/special.ts
@@ -148,6 +148,41 @@ const raw_sources: SourceSpecialInterface[] = [
             return await fetch_lib_notice({ general_id: '1387413', engine_id: '1722985', _hook })
         },
     },
+    {
+        name: '延河',
+        full_name: '延河课堂更新日志',
+        url: 'https://www.yanhekt.cn/supportCenter/releases',
+        guide: [
+            '延河课堂',
+            '右边栏',
+            '用户手册',
+            '左边栏',
+            '更新日志',
+        ],
+        async fetch_notice ({ _hook }) {
+            const response =
+                await hooked_fetch({
+                    url: 'https://cbiz.yanhekt.cn/v1/notice/list?with_brief=false',
+                    headers: {
+                        Referer: 'https://www.yanhekt.cn/',
+                        'Xdomain-Client': 'web_user',
+                    },
+                    _hook,
+                })
+            const json = await response.json() as { data: { title: string, created_at: string, id: number }[] }
+            const original_data = json.data
+
+            return original_data.map(
+                ({ title, created_at, id }) => ({
+                    link: 'https://www.yanhekt.cn/supportCenter/releases',
+                    id: `https://www.yanhekt.cn/supportCenter/releases#${id}`,
+                    // 无专门页面，延河课堂网页又不支持 hash（加了就不能正常显示），只好自制 id
+                    title,
+                    date: parse_date(created_at),
+                }),
+            )
+        },
+    },
 ]
 
 const sources = raw_sources.map(raw => {

--- a/src/plugin/rss/rss.ts
+++ b/src/plugin/rss/rss.ts
@@ -24,8 +24,8 @@ function to_feed_item (notice: Notice) {
             { link: notice.link },
             {
                 guid: [
-                    { _attr: { isPermaLink: true } },
-                    notice.link,
+                    { _attr: { isPermaLink: notice.id === notice.link } },
+                    notice.id,
                 ],
             },
             { description: { _cdata: description } },

--- a/src/util/my_date.test.ts
+++ b/src/util/my_date.test.ts
@@ -23,6 +23,9 @@ describe('解析日期', () => {
     it('完整的ISO字符串还是按ISO解析', () => {
         assert_date(parse_date('2021-12-10T20:00:00.000Z'), new Date('2021-12-10T20:00:00.000Z'))
     })
+    it('用空格分隔的ISO日期和时间', () => {
+        assert_date(parse_date('2023-03-31 17:28:49'), new Date(2023, 2, 31, 17, 28, 49))
+    })
     it('省略“年”时理解为当年', () => {
         assert_date(parse_date('1-1'), new Date((new Date()).getFullYear(), 0, 1))
     })

--- a/src/util/my_date.ts
+++ b/src/util/my_date.ts
@@ -4,7 +4,7 @@
  * @description 会忽略日期两边的字符。未标时区时采用本地时间。
  */
 export function parse_date (date: string) {
-    const match = date.match(/((?<year>\d+)[-/年])?(?<month>\d+)[-/月](?<day>\d+)日?((?<hour>\d+)时)?(?![-/T\d])/)
+    const match = date.match(/((?<year>\d+)[-/年])?(?<month>\d+)[-/月](?<day>\d+)日?((?<hour>\d+)时)?(?![-/T\s\d])/)
     if (match) {
         return new Date(parseInt(match.groups.year) || (new Date()).getFullYear(),
             parseInt(match.groups.month) - 1,


### PR DESCRIPTION
- 支持手动指定 id

  因为“延河”每一通知没有单独页面，它的网页有不支持 hash，因此无法用 URL 作 id。

- `parse_date`支持用空格分隔的 ISO 日期、时间

  “延河”用这种格式。

Resolves #17